### PR TITLE
feat: change docker base image to alpine

### DIFF
--- a/service_a/Dockerfile
+++ b/service_a/Dockerfile
@@ -1,11 +1,10 @@
-FROM centos
+FROM alpine
 
 WORKDIR /home/service-a
 
 COPY . .
 
-RUN dnf module enable nodejs:12 -y
-RUN dnf install nodejs -y
+RUN apk add --update nodejs npm
 RUN npm install
 
 EXPOSE 3000

--- a/service_b/Dockerfile
+++ b/service_b/Dockerfile
@@ -1,11 +1,10 @@
-FROM centos
+FROM alpine
 
 WORKDIR /home/service-b
 
 COPY . .
 
-RUN dnf module enable nodejs:12 -y
-RUN dnf install nodejs -y
+RUN apk add --update nodejs npm
 RUN npm install
 
 EXPOSE 3001

--- a/service_c/Dockerfile
+++ b/service_c/Dockerfile
@@ -1,12 +1,10 @@
-FROM centos
+FROM alpine
 
 WORKDIR /home/service-c
 
 COPY . .
 
-RUN dnf module enable nodejs:12 -y
-RUN dnf install nodejs -y
-# RUN dnf install git -y
+RUN apk add --update nodejs npm
 RUN npm install
 
 EXPOSE 3002

--- a/service_d/Dockerfile
+++ b/service_d/Dockerfile
@@ -1,12 +1,10 @@
-FROM centos
+FROM alpine
 
 WORKDIR /home/service-d
 
 COPY . .
 
-RUN dnf module enable nodejs:12 -y
-RUN dnf install nodejs -y
-# RUN dnf install git -y
+RUN apk add --update nodejs npm
 RUN npm install
 
 EXPOSE 3003


### PR DESCRIPTION
Change the Dockerfile of all microservices to use alpine image
instead of CentOS. The microservices with CentOS images were
too large (400MB+). With Alpine the microservices images are
around 120MB.

Resolve #3